### PR TITLE
Update mixdrop.co to mixdrop.ga embed Retrieval in PrimeWire Scraper

### DIFF
--- a/src/providers/sources/primewire/index.ts
+++ b/src/providers/sources/primewire/index.ts
@@ -39,7 +39,7 @@ async function getStreams(title: string) {
       const sourceName = element.parent().parent().parent().find('.version-host').text().trim();
       let embedId;
       switch (sourceName) {
-        case 'mixdrop.co':
+        case 'mixdrop.ga':
           embedId = 'mixdrop';
           break;
         case 'voe.sx':


### PR DESCRIPTION
PrimeWire scraper doesn't correctly retrieve the embed URLs for Mixdrop because it doesn't recognize the source name 'mixdrop.co'

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
